### PR TITLE
Get_Alert_Tasks Subplaybook DeleteContext Issue

### DIFF
--- a/SOC_Framework/Playbooks/playbook-Get_Alert_Tasks_and_Store_to_Dataset.yml
+++ b/SOC_Framework/Playbooks/playbook-Get_Alert_Tasks_and_Store_to_Dataset.yml
@@ -177,7 +177,7 @@ tasks:
     quietmode: 0
     scriptarguments:
       key:
-        simple: Task,Object
+        simple: Tasks,Object
       subplaybook:
         simple: "yes"
     separatecontext: false


### PR DESCRIPTION
Task 4 in the Get_Alert_Tasks_and_Store_to_Dataset playbook is used to delete sub-playbook context after each loop. This task specified to delete the "Task" context key, which does not exist in context, and is not set from other tasks. This causes issues with certain conditions where all the necessary context won't be deleted. This could result in future silent errors on alerts that do not have any attached playbooks that are ran AFTER a previous alert's playbook tasks are uploaded to the dataset.

Updated the input to delete the "Tasks" key, which should resolve the issue.