### PR TITLE
Resolve Foundation Dedup playbook issue

### DIFF
--- a/SOC_Framework/Playbooks/playbook-Foundation_-_Dedup.yml
+++ b/SOC_Framework/Playbooks/playbook-Foundation_-_Dedup.yml
@@ -74,7 +74,7 @@ tasks:
       description: |-
         Finds past similar incidents based on incident fields' similarity. Includes an option to also display indicators similarity.
         Note: For the similarity calculation, at least one field must be provided in one of the "similarTextField", "similarCategoricalField", or "similarJsonField" arguments.
-      scriptName: DBotFindSimilarIncidents
+      script: DBotFindSimilarAlerts
       type: regular
       iscommand: false
       brand: ""
@@ -156,7 +156,7 @@ tasks:
       version: -1
       name: Print Duplicate Alerts
       description: Prints text to war room (Markdown supported)
-      scriptName: Print
+      script: Print
       type: regular
       iscommand: false
       brand: ""


### PR DESCRIPTION
**Issue:** When previously pushed, the _Foundation - Dedup_ playbook's tasks labeled 'DeDup Alerts from the Last "1 days ago"' and  'Print Duplicate Alerts' would not have a script associated with it. The arguments would appear in the UI when the script was later picked. 

**Resolution**: 
- Changing the 'scriptName' key to 'script' as expected by the Custom Content bundle upload API
- Also, changing the 'DBotFindSimilarIncidents' back to 'DBotFindSimilarAlerts' to align with XSIAM content