### PR TITLE
Changing the XQL HTTP Collector to use a credential object for the to…

### DIFF
--- a/SOC_Framework/Integrations/integration-XQL_HTTP_Collector.yml
+++ b/SOC_Framework/Integrations/integration-XQL_HTTP_Collector.yml
@@ -16,9 +16,11 @@ configuration:
   section: Connect
   type: 8
 - display: ""
+  displaypassword: token
   name: token
+  type: 9
   required: true
-  type: 4
+  hiddenusername: true
 - display: ""
   name: url
   required: true
@@ -70,7 +72,7 @@ script:
             }
 
             if command in ['xql-post-to-dataset', 'test-module']:
-                Token = params.get("token")
+                Token = params.get("token").get("password")
 
                 URL = params.get("url")
 


### PR DESCRIPTION
Updated the token parameter of the XQL HTTP Collector to be an authenication type parameter instead of encrypted. This allows us to save the tokens as credential objects that we can then pass into the integration instance.