### PR TITLE
Adding logic to the integration to resolve encoding issues.

### DIFF
--- a/SOC_Framework/Integrations/integration-XQL_HTTP_Collector.yml
+++ b/SOC_Framework/Integrations/integration-XQL_HTTP_Collector.yml
@@ -82,7 +82,8 @@ script:
                 if command == 'test_module':
                     data = {"test": "test"}
                 else:
-                    data = demisto.args().get("JSON")
+                    # The docker image encoding defaults to Latin-1. Setting the encoding to UTF-8 to address Latin-1 encoding limitations.
+                    data = demisto.args().get("JSON","").encode()
 
                 res = requests.post(URL, headers=headers, data=data, verify=False)
 


### PR DESCRIPTION
The "xql-post-to-dataset" command in the "XQL HTTP Collector" integration defaults to posting data using Latin-1 encoding. This is causing several errors when trying to post data that has certain character sets.

Changed the posted data to be encoded using the more universal standard UTF-8.